### PR TITLE
feat: ResponseFormat に json_schema 構造化出力を追加

### DIFF
--- a/.sisyphus/notepads/create-response-format-tests/aar.md
+++ b/.sisyphus/notepads/create-response-format-tests/aar.md
@@ -1,0 +1,44 @@
+# After Action Report: Create ResponseFormat Tests
+
+## Task
+Create comprehensive tests for `ResponseFormat` sealed interface, `ResponseFormatSerializer`, and `ResponseFormatBuilder` DSL.
+
+## Outcome: SUCCESS
+
+All 3 test files created. 230+ tests pass (0 failures).
+
+## Files Created
+
+### 1. `src/test/kotlin/dev/toliner/openrouter/l1/chat/ResponseFormatTest.kt`
+- 11 tests covering round-trip serialization for all 5 variants (Text, JsonObject, JsonSchema, Grammar, Python)
+- Explicit JSON string assertions for Text, JsonObject, Grammar
+- JsonSchema with full config (nested schema object with properties, required, additionalProperties)
+- Verification that null optional fields (description, schema, strict) are omitted from JSON output
+- Deserialization with unknown fields (ignoreUnknownKeys behavior)
+
+### 2. `src/test/kotlin/dev/toliner/openrouter/serialization/ResponseFormatSerializerTest.kt`
+- ~25 tests organized in `context("deserialization")`, `context("serialization")`, `context("round-trip")`
+- Deserialization of all 5 variants from raw JSON strings
+- Error cases: unknown type → `IllegalStateException`, missing type field → `IllegalStateException`, grammar without grammar field, python without python field
+- Serialization producing correct JSON for all variants
+- Full round-trip tests for each variant
+
+### 3. `src/test/kotlin/dev/toliner/openrouter/l2/chat/ResponseFormatBuilderTest.kt`
+- 13 tests covering all builder methods
+- `text()`, `jsonObject()`, `grammar()`, `python()` simple format builders
+- `jsonSchema("name") { ... }` manual DSL builder with all fields
+- `jsonSchema<TestOutput>("name")` auto-generation from `@Serializable` type — verifies name, strict=true, and that schema contains "type":"object" and correct property names
+- `jsonSchema<T>` with description parameter
+- `jsonSchema<T>` with strict=false and strict=null parameters
+- `build()` without format method → `IllegalArgumentException`
+- `JsonSchemaConfigBuilder` direct tests
+- Integration via `chatRequest { responseFormat = ... }`
+
+## Bug Fixed During Development
+Initial test used `json.contains("description") shouldBe false` on a `JsonSchemaConfig` with `name = "no_description"`. The substring "description" appears in the schema name itself. Fixed by using `json.contains(""""description":""") shouldBe false` (checking for the JSON key pattern, not just the substring) and renaming the test schema to `"sparse_output"`.
+
+## Observations
+- `OpenRouterJson` is `internal` but accessible from tests in the same Gradle module
+- `ResponseFormatSerializer` is `internal` — tests access it indirectly via `ResponseFormat.serializer()` (the sealed interface's serializer)
+- The `shouldBeInstanceOf<T>()` Kotest assertion doesn't perform Kotlin smart-casts, so explicit `as T` is needed afterward — this produces "No cast needed" compiler warnings, which is a known pattern in the codebase (same seen in `ToolDslTest.kt`)
+- `kotlinx-schema` auto-generation via `SerializationClassJsonSchemaGenerator` works correctly for `@Serializable` data classes

--- a/.sisyphus/notepads/response-format-json-schema/aar.md
+++ b/.sisyphus/notepads/response-format-json-schema/aar.md
@@ -1,0 +1,39 @@
+# After Action Report: ResponseFormat json_schema Support
+
+## Task
+`ChatRequestBuilder.responseFormat` が構造化出力の `json_schema` 方式に対応していない問題の調査と修正。
+
+## Findings
+- `ResponseFormat` は `data class ResponseFormat(val type: String)` という単純な型で、`json_schema` に必要なネストオブジェクトを表現できなかった
+- OpenRouter API は `response_format` に5つのバリアント（text, json_object, json_schema, grammar, python）を持つ oneOf union 型を定義
+
+## Changes
+
+### Dependencies
+- `org.jetbrains.kotlinx:kotlinx-schema-generator-json:0.4.4` を追加（JetBrains製、@Serializable型からJSON Schema自動生成）
+
+### l1 Layer
+- `ResponseFormat` を `sealed interface` に変更（破壊的変更）
+- 5バリアント: `Text`, `JsonObject`, `JsonSchema`, `Grammar`, `Python`
+- `JsonSchemaConfig` data class 新設（name, description, schema, strict）
+
+### serialization Layer
+- `ResponseFormatSerializer` 新設 — `type` フィールドで分岐するカスタム KSerializer
+
+### l2 Layer
+- `ResponseFormatBuilder` DSL 新設
+  - `jsonSchema<T>(name)` — reified型パラメータから JSON Schema 自動生成
+  - `jsonSchema(name) { schema = ... }` — 手書きスキーマ
+  - `text()`, `jsonObject()`, `grammar()`, `python()`
+- `ChatRequestBuilder` に `responseFormat { }` DSL メソッド追加
+
+### Tests
+- `ResponseFormatTest.kt` — 11 round-trip tests
+- `ResponseFormatSerializerTest.kt` — ~25 serializer tests
+- `ResponseFormatBuilderTest.kt` — 13 DSL tests (auto-gen + manual)
+- 既存テスト2ファイル修正
+
+## Breaking Changes
+- `ResponseFormat(type = "json_object")` → `ResponseFormat.JsonObject`
+- `ResponseFormat(type = "text")` → `ResponseFormat.Text`
+- `responseFormat?.type` → pattern match on sealed subtypes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:3.4.1")
     implementation("io.ktor:ktor-sse:3.4.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-schema-generator-json:0.4.4")
 
     testImplementation("io.kotest:kotest-runner-junit5:6.1.0")
     testImplementation("io.kotest:kotest-assertions-core:6.1.0")

--- a/src/main/kotlin/dev/toliner/openrouter/l1/chat/ResponseFormat.kt
+++ b/src/main/kotlin/dev/toliner/openrouter/l1/chat/ResponseFormat.kt
@@ -1,26 +1,115 @@
 package dev.toliner.openrouter.l1.chat
 
+import dev.toliner.openrouter.serialization.ResponseFormatSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Specifies the format of the model's output.
  *
  * Response format constraints allow requesting specific output structures.
- * For example, "json_object" mode instructs the model to return valid JSON.
+ * This is a union type that serializes to different JSON shapes depending on the variant.
  *
- * Common values:
- * - "text": Standard text output (default)
- * - "json_object": Model will return a valid JSON object
+ * Common variants:
+ * - [Text]: Standard text output (default). Serializes to `{"type":"text"}`.
+ * - [JsonObject]: Model will return a valid JSON object. Serializes to `{"type":"json_object"}`.
+ * - [JsonSchema]: Structured output with a JSON Schema definition. Serializes to
+ *   `{"type":"json_schema","json_schema":{...}}`.
+ * - [Grammar]: GBNF grammar-constrained output (OpenRouter-specific). Serializes to
+ *   `{"type":"grammar","grammar":"..."}`.
+ * - [Python]: Python type-constrained output (OpenRouter-specific). Serializes to
+ *   `{"type":"python","python":"..."}`.
  *
  * Note: Not all models support all response format types.
  *
- * @property type The response format type.
- *
  * @see ChatCompletionRequest.responseFormat
+ * @see JsonSchemaConfig
+ */
+@Serializable(with = ResponseFormatSerializer::class)
+public sealed interface ResponseFormat {
+    /**
+     * Standard text output format (default).
+     *
+     * Serializes to `{"type":"text"}`.
+     */
+    public data object Text : ResponseFormat
+
+    /**
+     * JSON object output format.
+     *
+     * Instructs the model to return a valid JSON object.
+     * Serializes to `{"type":"json_object"}`.
+     */
+    public data object JsonObject : ResponseFormat
+
+    /**
+     * Structured output with a JSON Schema definition.
+     *
+     * Instructs the model to return output conforming to the given JSON Schema.
+     * Serializes to `{"type":"json_schema","json_schema":{...}}`.
+     *
+     * @property jsonSchema The JSON Schema configuration for structured output.
+     * @see JsonSchemaConfig
+     */
+    @Serializable
+    public data class JsonSchema(
+        @SerialName("json_schema")
+        val jsonSchema: JsonSchemaConfig
+    ) : ResponseFormat
+
+    /**
+     * GBNF grammar-constrained output format (OpenRouter-specific).
+     *
+     * Instructs the model to return output conforming to the given GBNF grammar.
+     * Serializes to `{"type":"grammar","grammar":"..."}`.
+     *
+     * @property grammar The GBNF grammar string.
+     */
+    @Serializable
+    public data class Grammar(
+        @SerialName("grammar")
+        val grammar: String
+    ) : ResponseFormat
+
+    /**
+     * Python type-constrained output format (OpenRouter-specific).
+     *
+     * Instructs the model to return output conforming to the given Python type definition.
+     * Serializes to `{"type":"python","python":"..."}`.
+     *
+     * @property python The Python type definition string.
+     */
+    @Serializable
+    public data class Python(
+        @SerialName("python")
+        val python: String
+    ) : ResponseFormat
+}
+
+/**
+ * Configuration for JSON Schema-based structured output.
+ *
+ * Defines the schema that the model's output must conform to. Used with
+ * [ResponseFormat.JsonSchema].
+ *
+ * @property name The schema name. Must match `[a-zA-Z0-9_-]` and be at most 64 characters.
+ * @property description Optional description of the schema for the model.
+ * @property schema Optional JSON Schema object defining the output structure.
+ *   When `null`, the model generates valid JSON without a specific schema constraint.
+ * @property strict Optional flag to enable strict schema adherence.
+ *   When `true`, the model will strictly follow the schema (e.g., no additional properties).
+ *
+ * @see ResponseFormat.JsonSchema
  */
 @Serializable
-public data class ResponseFormat(
-    @SerialName("type")
-    val type: String
+public data class JsonSchemaConfig(
+    @SerialName("name")
+    val name: String,
+    @SerialName("description")
+    val description: String? = null,
+    @SerialName("schema")
+    val schema: JsonObject? = null,
+    @SerialName("strict")
+    val strict: Boolean? = null
 )

--- a/src/main/kotlin/dev/toliner/openrouter/l2/chat/ChatRequestBuilder.kt
+++ b/src/main/kotlin/dev/toliner/openrouter/l2/chat/ChatRequestBuilder.kt
@@ -136,10 +136,33 @@ public class ChatRequestBuilder {
     /**
      * Format specification for the model's output.
      *
-     * Use this to request JSON mode or other structured output formats.
+     * Use the [responseFormat] DSL method for a convenient builder, or set this directly.
      * @see ResponseFormat for available options
+     * @see responseFormat for the DSL configuration method
      */
     public var responseFormat: ResponseFormat? = null
+    
+    /**
+     * Configures the response format using a DSL builder.
+     *
+     * Example:
+     * ```kotlin
+     * chatRequest {
+     *     model = "openai/gpt-4o"
+     *     userMessage("Extract user info")
+     *     responseFormat {
+     *         jsonSchema<UserInfo>("user_info")
+     *     }
+     * }
+     * ```
+     *
+     * @param block Configuration block executed in the context of [ResponseFormatBuilder].
+     * @see ResponseFormatBuilder
+     * @see ResponseFormat
+     */
+    public fun responseFormat(block: ResponseFormatBuilder.() -> Unit) {
+        this.responseFormat = ResponseFormatBuilder().apply(block).build()
+    }
     
     /**
      * Provider routing preferences for the request.

--- a/src/main/kotlin/dev/toliner/openrouter/l2/chat/ResponseFormatBuilder.kt
+++ b/src/main/kotlin/dev/toliner/openrouter/l2/chat/ResponseFormatBuilder.kt
@@ -1,0 +1,196 @@
+package dev.toliner.openrouter.l2.chat
+
+import dev.toliner.openrouter.l1.chat.JsonSchemaConfig
+import dev.toliner.openrouter.l1.chat.ResponseFormat
+import dev.toliner.openrouter.l2.OpenRouterDslMarker
+import kotlinx.schema.generator.json.JsonSchemaConfig as KotlinxJsonSchemaConfig
+import kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaGenerator
+import kotlinx.schema.json.encodeToJsonObject
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.serializer
+
+/**
+ * DSL builder for constructing [ResponseFormat] instances.
+ *
+ * Provides convenient methods for each response format variant, including
+ * automatic JSON Schema generation from `@Serializable` Kotlin types.
+ *
+ * @see ResponseFormat
+ */
+@OpenRouterDslMarker
+public class ResponseFormatBuilder {
+    private var result: ResponseFormat? = null
+
+    /**
+     * Sets the response format to plain text output.
+     */
+    public fun text() {
+        result = ResponseFormat.Text
+    }
+
+    /**
+     * Sets the response format to JSON object mode.
+     */
+    public fun jsonObject() {
+        result = ResponseFormat.JsonObject
+    }
+
+    /**
+     * Sets the response format to JSON Schema mode with a schema auto-generated from the
+     * given `@Serializable` type [T].
+     *
+     * The schema is generated at runtime using the type's [kotlinx.serialization.descriptors.SerialDescriptor],
+     * with strict mode settings suitable for structured output (all fields required, no additional properties).
+     *
+     * Example:
+     * ```kotlin
+     * @Serializable
+     * data class UserInfo(val name: String, val age: Int)
+     *
+     * chatRequest {
+     *     model = "openai/gpt-4o"
+     *     userMessage("Extract user info")
+     *     responseFormat {
+     *         jsonSchema<UserInfo>("user_info")
+     *     }
+     * }
+     * ```
+     *
+     * @param T The `@Serializable` type to generate the schema from.
+     * @param name The schema name (must match `[a-zA-Z0-9_-]`, max 64 chars).
+     * @param description Optional description of the schema for the model.
+     * @param strict Whether to enable strict schema adherence. Defaults to `true`.
+     */
+    public inline fun <reified T> jsonSchema(
+        name: String,
+        description: String? = null,
+        strict: Boolean? = true
+    ) {
+        jsonSchema(name, serializer<T>(), description, strict)
+    }
+
+    /**
+     * Sets the response format to JSON Schema mode with a schema auto-generated from the
+     * given serializer's descriptor.
+     *
+     * @param name The schema name (must match `[a-zA-Z0-9_-]`, max 64 chars).
+     * @param serializer The [KSerializer] whose descriptor will be used to generate the schema.
+     * @param description Optional description of the schema for the model.
+     * @param strict Whether to enable strict schema adherence. Defaults to `true`.
+     */
+    public fun <T> jsonSchema(
+        name: String,
+        serializer: KSerializer<T>,
+        description: String? = null,
+        strict: Boolean? = true
+    ) {
+        val generator = SerializationClassJsonSchemaGenerator(
+            json = Json.Default,
+            jsonSchemaConfig = KotlinxJsonSchemaConfig.Strict,
+        )
+        val generatedSchema = generator.generateSchema(serializer.descriptor)
+        val schemaJsonObject = generatedSchema.encodeToJsonObject()
+
+        result = ResponseFormat.JsonSchema(
+            jsonSchema = JsonSchemaConfig(
+                name = name,
+                description = description,
+                schema = schemaJsonObject,
+                strict = strict
+            )
+        )
+    }
+
+    /**
+     * Sets the response format to JSON Schema mode with a manually specified schema.
+     *
+     * Use this when you need fine-grained control over the JSON Schema definition,
+     * such as complex validation constraints or patterns not expressible through
+     * `@Serializable` data classes.
+     *
+     * Example:
+     * ```kotlin
+     * chatRequest {
+     *     model = "openai/gpt-4o"
+     *     userMessage("Extract data")
+     *     responseFormat {
+     *         jsonSchema("my_schema") {
+     *             description = "Custom schema"
+     *             strict = true
+     *             schema = buildJsonObject {
+     *                 put("type", "object")
+     *                 putJsonObject("properties") {
+     *                     putJsonObject("name") { put("type", "string") }
+     *                 }
+     *                 putJsonArray("required") { add("name") }
+     *                 put("additionalProperties", false)
+     *             }
+     *         }
+     *     }
+     * }
+     * ```
+     *
+     * @param name The schema name (must match `[a-zA-Z0-9_-]`, max 64 chars).
+     * @param block Configuration block for [JsonSchemaConfigBuilder].
+     */
+    public fun jsonSchema(name: String, block: JsonSchemaConfigBuilder.() -> Unit) {
+        val config = JsonSchemaConfigBuilder(name).apply(block).build()
+        result = ResponseFormat.JsonSchema(jsonSchema = config)
+    }
+
+    /**
+     * Sets the response format to GBNF grammar-constrained mode (OpenRouter-specific).
+     *
+     * @param grammar The GBNF grammar string.
+     */
+    public fun grammar(grammar: String) {
+        result = ResponseFormat.Grammar(grammar = grammar)
+    }
+
+    /**
+     * Sets the response format to Python type-constrained mode (OpenRouter-specific).
+     *
+     * @param python The Python type definition string.
+     */
+    public fun python(python: String) {
+        result = ResponseFormat.Python(python = python)
+    }
+
+    internal fun build(): ResponseFormat {
+        return requireNotNull(result) { "responseFormat must specify a format (text(), jsonObject(), jsonSchema(), etc.)" }
+    }
+}
+
+/**
+ * DSL builder for manually constructing [JsonSchemaConfig] instances.
+ *
+ * @see ResponseFormatBuilder.jsonSchema
+ */
+@OpenRouterDslMarker
+public class JsonSchemaConfigBuilder(private val name: String) {
+    /**
+     * Optional description of the schema for the model.
+     */
+    public var description: String? = null
+
+    /**
+     * The JSON Schema object defining the output structure.
+     */
+    public var schema: JsonObject? = null
+
+    /**
+     * Whether to enable strict schema adherence.
+     */
+    public var strict: Boolean? = null
+
+    internal fun build(): JsonSchemaConfig {
+        return JsonSchemaConfig(
+            name = name,
+            description = description,
+            schema = schema,
+            strict = strict
+        )
+    }
+}

--- a/src/main/kotlin/dev/toliner/openrouter/serialization/ResponseFormatSerializer.kt
+++ b/src/main/kotlin/dev/toliner/openrouter/serialization/ResponseFormatSerializer.kt
@@ -1,0 +1,84 @@
+package dev.toliner.openrouter.serialization
+
+import dev.toliner.openrouter.l1.chat.JsonSchemaConfig
+import dev.toliner.openrouter.l1.chat.ResponseFormat
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+internal object ResponseFormatSerializer : KSerializer<ResponseFormat> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ResponseFormat")
+
+    override fun deserialize(decoder: Decoder): ResponseFormat {
+        require(decoder is JsonDecoder) { "This serializer only works with Json format" }
+
+        val element = decoder.decodeJsonElement().jsonObject
+        val type = element["type"]?.jsonPrimitive?.content
+            ?: error("ResponseFormat must have a 'type' field")
+
+        return when (type) {
+            "text" -> ResponseFormat.Text
+            "json_object" -> ResponseFormat.JsonObject
+            "json_schema" -> {
+                @Serializable
+                data class JsonSchemaWrapper(
+                    @SerialName("json_schema")
+                    val jsonSchema: JsonSchemaConfig
+                )
+                val wrapper = decoder.json.decodeFromJsonElement(JsonSchemaWrapper.serializer(), JsonObject(element))
+                ResponseFormat.JsonSchema(jsonSchema = wrapper.jsonSchema)
+            }
+            "grammar" -> {
+                val grammar = element["grammar"]?.jsonPrimitive?.content
+                    ?: error("ResponseFormat 'grammar' variant must have a 'grammar' field")
+                ResponseFormat.Grammar(grammar = grammar)
+            }
+            "python" -> {
+                val python = element["python"]?.jsonPrimitive?.content
+                    ?: error("ResponseFormat 'python' variant must have a 'python' field")
+                ResponseFormat.Python(python = python)
+            }
+            else -> error("Unknown ResponseFormat type: $type")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: ResponseFormat) {
+        require(encoder is JsonEncoder) { "This serializer only works with Json format" }
+
+        val jsonElement = when (value) {
+            is ResponseFormat.Text -> buildJsonObject { put("type", "text") }
+            is ResponseFormat.JsonObject -> buildJsonObject { put("type", "json_object") }
+            is ResponseFormat.JsonSchema -> {
+                @Serializable
+                data class JsonSchemaFormat(
+                    @SerialName("type") val type: String,
+                    @SerialName("json_schema") val jsonSchema: JsonSchemaConfig
+                )
+                encoder.json.encodeToJsonElement(
+                    JsonSchemaFormat.serializer(),
+                    JsonSchemaFormat(type = "json_schema", jsonSchema = value.jsonSchema)
+                )
+            }
+            is ResponseFormat.Grammar -> buildJsonObject {
+                put("type", "grammar")
+                put("grammar", value.grammar)
+            }
+            is ResponseFormat.Python -> buildJsonObject {
+                put("type", "python")
+                put("python", value.python)
+            }
+        }
+        encoder.encodeJsonElement(jsonElement)
+    }
+}

--- a/src/test/kotlin/dev/toliner/openrouter/l1/chat/ChatCompletionTypesTest.kt
+++ b/src/test/kotlin/dev/toliner/openrouter/l1/chat/ChatCompletionTypesTest.kt
@@ -99,7 +99,7 @@ class ChatCompletionTypesTest : FunSpec({
     }
     
     test("ResponseFormat serialization round-trip") {
-        val format = ResponseFormat(type = "json_object")
+        val format = ResponseFormat.JsonObject
         val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), format)
         val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
         
@@ -181,7 +181,7 @@ class ChatCompletionTypesTest : FunSpec({
                 )
             ),
             toolChoice = dev.toliner.openrouter.serialization.ToolChoice.Mode("auto"),
-            responseFormat = ResponseFormat(type = "json_object"),
+            responseFormat = ResponseFormat.JsonObject,
             provider = ProviderPreferences(order = listOf("OpenAI")),
             trace = Trace(traceId = "trace_1"),
             transforms = listOf("middle-out")

--- a/src/test/kotlin/dev/toliner/openrouter/l1/chat/ResponseFormatTest.kt
+++ b/src/test/kotlin/dev/toliner/openrouter/l1/chat/ResponseFormatTest.kt
@@ -1,0 +1,145 @@
+package dev.toliner.openrouter.l1.chat
+
+import dev.toliner.openrouter.serialization.OpenRouterJson
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+class ResponseFormatTest : FunSpec({
+
+    test("ResponseFormat.Text round-trip serialization") {
+        val original: ResponseFormat = ResponseFormat.Text
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+        decoded shouldBe original
+        json shouldBe """{"type":"text"}"""
+    }
+
+    test("ResponseFormat.JsonObject round-trip serialization") {
+        val original: ResponseFormat = ResponseFormat.JsonObject
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+        decoded shouldBe original
+        json shouldBe """{"type":"json_object"}"""
+    }
+
+    test("ResponseFormat.JsonSchema with full config round-trip serialization") {
+        val format = ResponseFormat.JsonSchema(
+            jsonSchema = JsonSchemaConfig(
+                name = "test_schema",
+                description = "A test schema",
+                schema = buildJsonObject {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("name") { put("type", "string") }
+                        putJsonObject("age") { put("type", "integer") }
+                    }
+                    putJsonArray("required") { add("name"); add("age") }
+                    put("additionalProperties", false)
+                },
+                strict = true
+            )
+        )
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), format)
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+        decoded shouldBe format
+    }
+
+    test("ResponseFormat.JsonSchema serializes to correct type field") {
+        val format = ResponseFormat.JsonSchema(
+            jsonSchema = JsonSchemaConfig(
+                name = "simple_schema",
+                strict = true
+            )
+        )
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), format)
+
+        json.contains(""""type":"json_schema"""") shouldBe true
+        json.contains(""""name":"simple_schema"""") shouldBe true
+    }
+
+    test("ResponseFormat.Grammar round-trip serialization") {
+        val original: ResponseFormat = ResponseFormat.Grammar(grammar = "root ::= \"hello\" | \"world\"")
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+        decoded shouldBe original
+        json shouldBe """{"type":"grammar","grammar":"root ::= \"hello\" | \"world\""}"""
+    }
+
+    test("ResponseFormat.Python round-trip serialization") {
+        val original: ResponseFormat = ResponseFormat.Python(python = "class Output(BaseModel):\n    name: str\n    score: int")
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+        decoded shouldBe original
+    }
+
+    test("ResponseFormat.Python serializes to correct type and python fields") {
+        val pythonCode = "class Output(BaseModel): ..."
+        val original: ResponseFormat = ResponseFormat.Python(python = pythonCode)
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+
+        json.contains(""""type":"python"""") shouldBe true
+        json.contains(""""python":""") shouldBe true
+    }
+
+    test("ResponseFormat.JsonSchema with minimal config round-trip") {
+        val original: ResponseFormat = ResponseFormat.JsonSchema(
+            jsonSchema = JsonSchemaConfig(name = "minimal")
+        )
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+        decoded shouldBe original
+    }
+
+    test("Deserialization ignores unknown fields in json_schema response format") {
+        val jsonWithExtras = """{"type":"json_schema","json_schema":{"name":"my_schema","strict":true},"extra_field":"ignored"}"""
+
+        shouldNotThrowAny {
+            OpenRouterJson.decodeFromString(ResponseFormat.serializer(), jsonWithExtras)
+        }
+
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), jsonWithExtras)
+        decoded shouldBe ResponseFormat.JsonSchema(
+            jsonSchema = JsonSchemaConfig(name = "my_schema", strict = true)
+        )
+    }
+
+    test("Deserialization ignores unknown fields in text response format") {
+        val jsonWithExtras = """{"type":"text","unexpected_key":"value"}"""
+
+        shouldNotThrowAny {
+            OpenRouterJson.decodeFromString(ResponseFormat.serializer(), jsonWithExtras)
+        }
+
+        val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), jsonWithExtras)
+        decoded shouldBe ResponseFormat.Text
+    }
+
+    test("ResponseFormat.JsonSchema null optional fields are omitted in serialization") {
+        val format = ResponseFormat.JsonSchema(
+            jsonSchema = JsonSchemaConfig(
+                name = "sparse_output",
+                description = null,
+                schema = null,
+                strict = null
+            )
+        )
+        val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), format)
+
+        json.contains(""""description":""") shouldBe false
+        json.contains(""""schema":""") shouldBe false
+        json.contains(""""strict":""") shouldBe false
+        json.contains(""""name":"sparse_output"""") shouldBe true
+    }
+})

--- a/src/test/kotlin/dev/toliner/openrouter/l2/chat/ChatDslTest.kt
+++ b/src/test/kotlin/dev/toliner/openrouter/l2/chat/ChatDslTest.kt
@@ -47,7 +47,7 @@ class ChatDslTest : FunSpec({
             repetitionPenalty = 1.1
             seed = 42
             stop = StringOrArray.Single("STOP")
-            responseFormat = ResponseFormat(type = "json_object")
+            responseFormat = ResponseFormat.JsonObject
             
             systemMessage("You are a helpful assistant.")
             userMessage("What is Kotlin?")
@@ -65,7 +65,7 @@ class ChatDslTest : FunSpec({
         request.repetitionPenalty shouldBe 1.1
         request.seed shouldBe 42
         request.stop.shouldNotBeNull()
-        request.responseFormat?.type shouldBe "json_object"
+        request.responseFormat shouldBe ResponseFormat.JsonObject
         
         request.messages shouldHaveSize 4
         request.messages[0].shouldBeInstanceOf<Message.System>()

--- a/src/test/kotlin/dev/toliner/openrouter/l2/chat/ResponseFormatBuilderTest.kt
+++ b/src/test/kotlin/dev/toliner/openrouter/l2/chat/ResponseFormatBuilderTest.kt
@@ -1,0 +1,196 @@
+package dev.toliner.openrouter.l2.chat
+
+import dev.toliner.openrouter.l1.chat.JsonSchemaConfig
+import dev.toliner.openrouter.l1.chat.ResponseFormat
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+@Serializable
+private data class TestOutput(
+    @SerialName("name") val name: String,
+    @SerialName("score") val score: Int,
+    @SerialName("tags") val tags: List<String>
+)
+
+class ResponseFormatBuilderTest : FunSpec({
+
+    test("text() produces ResponseFormat.Text") {
+        val result = ResponseFormatBuilder().apply { text() }.build()
+
+        result shouldBe ResponseFormat.Text
+    }
+
+    test("jsonObject() produces ResponseFormat.JsonObject") {
+        val result = ResponseFormatBuilder().apply { jsonObject() }.build()
+
+        result shouldBe ResponseFormat.JsonObject
+    }
+
+    test("grammar() produces correct ResponseFormat.Grammar") {
+        val grammarStr = "root ::= [a-zA-Z]+"
+        val result = ResponseFormatBuilder().apply { grammar(grammarStr) }.build()
+
+        result shouldBe ResponseFormat.Grammar(grammar = grammarStr)
+    }
+
+    test("python() produces correct ResponseFormat.Python") {
+        val pythonCode = "class Output(BaseModel):\n    name: str\n    score: int"
+        val result = ResponseFormatBuilder().apply { python(pythonCode) }.build()
+
+        result shouldBe ResponseFormat.Python(python = pythonCode)
+    }
+
+    test("jsonSchema(name) { ... } manual builder produces correct ResponseFormat.JsonSchema") {
+        val schema = buildJsonObject {
+            put("type", "object")
+            putJsonObject("properties") {
+                putJsonObject("name") { put("type", "string") }
+                putJsonObject("age") { put("type", "integer") }
+            }
+            putJsonArray("required") { add("name"); add("age") }
+            put("additionalProperties", false)
+        }
+
+        val result = ResponseFormatBuilder().apply {
+            jsonSchema("my_schema") {
+                description = "Custom schema for testing"
+                strict = true
+                this.schema = schema
+            }
+        }.build()
+
+        result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+        val jsonSchemaFormat = result as ResponseFormat.JsonSchema
+        jsonSchemaFormat.jsonSchema.name shouldBe "my_schema"
+        jsonSchemaFormat.jsonSchema.description shouldBe "Custom schema for testing"
+        jsonSchemaFormat.jsonSchema.strict shouldBe true
+        jsonSchemaFormat.jsonSchema.schema shouldBe schema
+    }
+
+    test("jsonSchema(name) { ... } with null fields produces ResponseFormat.JsonSchema with null optionals") {
+        val result = ResponseFormatBuilder().apply {
+            jsonSchema("bare_schema") {}
+        }.build()
+
+        result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+        val jsonSchemaFormat = result as ResponseFormat.JsonSchema
+        jsonSchemaFormat.jsonSchema.name shouldBe "bare_schema"
+        jsonSchemaFormat.jsonSchema.description shouldBe null
+        jsonSchemaFormat.jsonSchema.schema shouldBe null
+        jsonSchemaFormat.jsonSchema.strict shouldBe null
+    }
+
+    test("jsonSchema<T>(name) auto-generates schema from @Serializable type") {
+        val result = ResponseFormatBuilder().apply {
+            jsonSchema<TestOutput>("test_output")
+        }.build()
+
+        result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+        val jsonSchemaFormat = result as ResponseFormat.JsonSchema
+        jsonSchemaFormat.jsonSchema.name shouldBe "test_output"
+        jsonSchemaFormat.jsonSchema.strict shouldBe true
+        jsonSchemaFormat.jsonSchema.schema.shouldNotBeNull()
+
+        val schema = jsonSchemaFormat.jsonSchema.schema!!
+        schema["type"]?.toString() shouldBe """"object""""
+        schema["properties"].shouldNotBeNull()
+        val properties = schema["properties"]!!
+        properties.toString().contains("name") shouldBe true
+        properties.toString().contains("score") shouldBe true
+        properties.toString().contains("tags") shouldBe true
+    }
+
+    test("jsonSchema<T>(name, description) includes description in config") {
+        val result = ResponseFormatBuilder().apply {
+            jsonSchema<TestOutput>("test_output", description = "Extracts test output from text")
+        }.build()
+
+        result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+        val jsonSchemaFormat = result as ResponseFormat.JsonSchema
+        jsonSchemaFormat.jsonSchema.name shouldBe "test_output"
+        jsonSchemaFormat.jsonSchema.description shouldBe "Extracts test output from text"
+    }
+
+    test("jsonSchema<T>(name, strict=false) sets strict to false") {
+        val result = ResponseFormatBuilder().apply {
+            jsonSchema<TestOutput>("test_output_loose", strict = false)
+        }.build()
+
+        result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+        val jsonSchemaFormat = result as ResponseFormat.JsonSchema
+        jsonSchemaFormat.jsonSchema.name shouldBe "test_output_loose"
+        jsonSchemaFormat.jsonSchema.strict shouldBe false
+    }
+
+    test("jsonSchema<T>(name, strict=null) sets strict to null") {
+        val result = ResponseFormatBuilder().apply {
+            jsonSchema<TestOutput>("test_output_no_strict", strict = null)
+        }.build()
+
+        result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+        val jsonSchemaFormat = result as ResponseFormat.JsonSchema
+        jsonSchemaFormat.jsonSchema.strict shouldBe null
+    }
+
+    test("build() without calling any format method throws IllegalArgumentException") {
+        shouldThrow<IllegalArgumentException> {
+            ResponseFormatBuilder().build()
+        }
+    }
+
+    test("build() error message is descriptive") {
+        val exception = runCatching {
+            ResponseFormatBuilder().build()
+        }.exceptionOrNull()
+
+        exception.shouldNotBeNull()
+        exception.shouldBeInstanceOf<IllegalArgumentException>()
+    }
+
+    test("responseFormat DSL in chatRequest produces correct format") {
+        val request = chatRequest {
+            model = "openai/gpt-4o"
+            userMessage("Hello")
+            responseFormat = ResponseFormat.Text
+        }
+
+        request.responseFormat shouldBe ResponseFormat.Text
+    }
+
+    test("JsonSchemaConfigBuilder sets all fields correctly") {
+        val schema = buildJsonObject { put("type", "object") }
+        val config = JsonSchemaConfigBuilder("config_test").apply {
+            description = "Test description"
+            this.schema = schema
+            strict = true
+        }.build()
+
+        config shouldBe JsonSchemaConfig(
+            name = "config_test",
+            description = "Test description",
+            schema = schema,
+            strict = true
+        )
+    }
+
+    test("JsonSchemaConfigBuilder with only name builds minimal config") {
+        val config = JsonSchemaConfigBuilder("only_name").build()
+
+        config shouldBe JsonSchemaConfig(
+            name = "only_name",
+            description = null,
+            schema = null,
+            strict = null
+        )
+    }
+})

--- a/src/test/kotlin/dev/toliner/openrouter/serialization/ResponseFormatSerializerTest.kt
+++ b/src/test/kotlin/dev/toliner/openrouter/serialization/ResponseFormatSerializerTest.kt
@@ -1,0 +1,260 @@
+package dev.toliner.openrouter.serialization
+
+import dev.toliner.openrouter.l1.chat.JsonSchemaConfig
+import dev.toliner.openrouter.l1.chat.ResponseFormat
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+class ResponseFormatSerializerTest : FunSpec({
+
+    context("deserialization") {
+        test("deserializing {\"type\":\"text\"} produces ResponseFormat.Text") {
+            val json = """{"type":"text"}"""
+            val result = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+            result shouldBe ResponseFormat.Text
+        }
+
+        test("deserializing {\"type\":\"json_object\"} produces ResponseFormat.JsonObject") {
+            val json = """{"type":"json_object"}"""
+            val result = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+            result shouldBe ResponseFormat.JsonObject
+        }
+
+        test("deserializing full json_schema JSON produces correct ResponseFormat.JsonSchema") {
+            val json = """
+                {
+                  "type": "json_schema",
+                  "json_schema": {
+                    "name": "output_schema",
+                    "description": "Schema for structured output",
+                    "schema": {
+                      "type": "object",
+                      "properties": {
+                        "name": {"type": "string"},
+                        "age": {"type": "integer"}
+                      },
+                      "required": ["name", "age"],
+                      "additionalProperties": false
+                    },
+                    "strict": true
+                  }
+                }
+            """.trimIndent()
+
+            val result = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+            result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+            val jsonSchema = result as ResponseFormat.JsonSchema
+            jsonSchema.jsonSchema.name shouldBe "output_schema"
+            jsonSchema.jsonSchema.description shouldBe "Schema for structured output"
+            jsonSchema.jsonSchema.strict shouldBe true
+            jsonSchema.jsonSchema.schema shouldBe buildJsonObject {
+                put("type", "object")
+                putJsonObject("properties") {
+                    putJsonObject("name") { put("type", "string") }
+                    putJsonObject("age") { put("type", "integer") }
+                }
+                putJsonArray("required") { add("name"); add("age") }
+                put("additionalProperties", false)
+            }
+        }
+
+        test("deserializing json_schema with minimal fields produces correct ResponseFormat.JsonSchema") {
+            val json = """{"type":"json_schema","json_schema":{"name":"minimal_schema"}}"""
+            val result = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+            result.shouldBeInstanceOf<ResponseFormat.JsonSchema>()
+            val jsonSchema = result as ResponseFormat.JsonSchema
+            jsonSchema.jsonSchema.name shouldBe "minimal_schema"
+            jsonSchema.jsonSchema.description shouldBe null
+            jsonSchema.jsonSchema.schema shouldBe null
+            jsonSchema.jsonSchema.strict shouldBe null
+        }
+
+        test("deserializing grammar JSON produces correct ResponseFormat.Grammar") {
+            val grammarStr = "root ::= \"hello\" | \"world\""
+            val json = """{"type":"grammar","grammar":"root ::= \"hello\" | \"world\""}"""
+            val result = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+            result shouldBe ResponseFormat.Grammar(grammar = grammarStr)
+        }
+
+        test("deserializing python JSON produces correct ResponseFormat.Python") {
+            val pythonCode = "class Output(BaseModel):\n    name: str"
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), ResponseFormat.Python(python = pythonCode))
+            val result = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+
+            result shouldBe ResponseFormat.Python(python = pythonCode)
+        }
+
+        test("deserializing unknown type throws error") {
+            val json = """{"type":"unsupported_format"}"""
+
+            shouldThrow<IllegalStateException> {
+                OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            }
+        }
+
+        test("deserializing missing type field throws error") {
+            val json = """{"json_schema":{"name":"no_type"}}"""
+
+            shouldThrow<IllegalStateException> {
+                OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            }
+        }
+
+        test("deserializing grammar type without grammar field throws error") {
+            val json = """{"type":"grammar"}"""
+
+            shouldThrow<IllegalStateException> {
+                OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            }
+        }
+
+        test("deserializing python type without python field throws error") {
+            val json = """{"type":"python"}"""
+
+            shouldThrow<IllegalStateException> {
+                OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            }
+        }
+    }
+
+    context("serialization") {
+        test("serializing ResponseFormat.Text produces correct JSON") {
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), ResponseFormat.Text)
+
+            json shouldBe """{"type":"text"}"""
+        }
+
+        test("serializing ResponseFormat.JsonObject produces correct JSON") {
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), ResponseFormat.JsonObject)
+
+            json shouldBe """{"type":"json_object"}"""
+        }
+
+        test("serializing ResponseFormat.Grammar produces correct JSON") {
+            val grammar = "root ::= [a-z]+"
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), ResponseFormat.Grammar(grammar = grammar))
+
+            json shouldBe """{"type":"grammar","grammar":"root ::= [a-z]+"}"""
+        }
+
+        test("serializing ResponseFormat.Python produces correct JSON") {
+            val python = "class Output(BaseModel): ..."
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), ResponseFormat.Python(python = python))
+
+            json shouldBe """{"type":"python","python":"class Output(BaseModel): ..."}"""
+        }
+
+        test("serializing ResponseFormat.JsonSchema produces correct type field") {
+            val format = ResponseFormat.JsonSchema(
+                jsonSchema = JsonSchemaConfig(
+                    name = "test_schema",
+                    strict = true
+                )
+            )
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), format)
+
+            json.contains(""""type":"json_schema"""") shouldBe true
+            json.contains(""""name":"test_schema"""") shouldBe true
+            json.contains(""""strict":true""") shouldBe true
+        }
+
+        test("serializing ResponseFormat.JsonSchema with full schema produces valid JSON") {
+            val format = ResponseFormat.JsonSchema(
+                jsonSchema = JsonSchemaConfig(
+                    name = "full_schema",
+                    description = "A full schema",
+                    schema = buildJsonObject {
+                        put("type", "object")
+                        putJsonObject("properties") {
+                            putJsonObject("field") { put("type", "string") }
+                        }
+                    },
+                    strict = false
+                )
+            )
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), format)
+
+            json.contains(""""type":"json_schema"""") shouldBe true
+            json.contains(""""name":"full_schema"""") shouldBe true
+            json.contains(""""description":"A full schema"""") shouldBe true
+            json.contains(""""strict":false""") shouldBe true
+        }
+
+        test("serializing ResponseFormat.JsonSchema with null fields omits them") {
+            val format = ResponseFormat.JsonSchema(
+                jsonSchema = JsonSchemaConfig(
+                    name = "sparse_schema",
+                    description = null,
+                    schema = null,
+                    strict = null
+                )
+            )
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), format)
+
+            json.contains("description") shouldBe false
+            json.contains("\"schema\"") shouldBe false
+            json.contains("strict") shouldBe false
+        }
+    }
+
+    context("round-trip") {
+        test("ResponseFormat.Text round-trips correctly") {
+            val original: ResponseFormat = ResponseFormat.Text
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+            val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("ResponseFormat.JsonObject round-trips correctly") {
+            val original: ResponseFormat = ResponseFormat.JsonObject
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+            val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("ResponseFormat.Grammar round-trips correctly") {
+            val original: ResponseFormat = ResponseFormat.Grammar(grammar = "root ::= \"yes\" | \"no\"")
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+            val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("ResponseFormat.Python round-trips correctly") {
+            val original: ResponseFormat = ResponseFormat.Python(python = "class Result(BaseModel):\n    value: int")
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+            val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            decoded shouldBe original
+        }
+
+        test("ResponseFormat.JsonSchema round-trips correctly") {
+            val original: ResponseFormat = ResponseFormat.JsonSchema(
+                jsonSchema = JsonSchemaConfig(
+                    name = "roundtrip_schema",
+                    description = "Round-trip test",
+                    schema = buildJsonObject {
+                        put("type", "object")
+                        putJsonObject("properties") {
+                            putJsonObject("id") { put("type", "integer") }
+                        }
+                    },
+                    strict = true
+                )
+            )
+            val json = OpenRouterJson.encodeToString(ResponseFormat.serializer(), original)
+            val decoded = OpenRouterJson.decodeFromString(ResponseFormat.serializer(), json)
+            decoded shouldBe original
+        }
+    }
+})


### PR DESCRIPTION
## Summary

- `ResponseFormat` を `data class` から `sealed interface` に変更し、OpenRouter API の全5バリアント（`text`, `json_object`, `json_schema`, `grammar`, `python`）に対応
- `kotlinx-schema` (JetBrains) を使い、`@Serializable` 型から JSON Schema を自動生成する `jsonSchema<T>()` DSL メソッドを追加
- 手書き JSON Schema にも `jsonSchema("name") { schema = ... }` で対応

## Usage

```kotlin
// 自動生成（@Serializable 型から）
@Serializable
data class UserInfo(val name: String, val age: Int)

client.chat {
    model = "openai/gpt-4o"
    userMessage("Extract user info")
    responseFormat {
        jsonSchema<UserInfo>("user_info")
    }
}

// 手書きスキーマ
responseFormat {
    jsonSchema("custom") {
        strict = true
        schema = buildJsonObject { /* ... */ }
    }
}
```

## Changes

### New Files
- `l1/chat/ResponseFormat.kt` — Sealed interface with 5 variants + `JsonSchemaConfig`
- `serialization/ResponseFormatSerializer.kt` — Custom KSerializer
- `l2/chat/ResponseFormatBuilder.kt` — DSL builder with `jsonSchema<T>()` auto-generation
- 3 new test files (49 tests total)

### Modified Files
- `build.gradle.kts` — Added `kotlinx-schema-generator-json:0.4.4`
- `l2/chat/ChatRequestBuilder.kt` — Added `responseFormat {}` DSL method
- 2 existing test files fixed

## Breaking Changes

- `ResponseFormat(type = "json_object")` → `ResponseFormat.JsonObject`
- `ResponseFormat(type = "text")` → `ResponseFormat.Text`
- `responseFormat?.type` → sealed subtype pattern matching
